### PR TITLE
Add children components to ForceAtlas2

### DIFF
--- a/src/ForceAtlas2.js
+++ b/src/ForceAtlas2.js
@@ -118,8 +118,8 @@ class ForceAtlas2 extends React.Component {
 	//strip force atlas options from component props
   _stripOptions(props: Props): Props {
         return Object.assign({}, props, {
-            sigma: undefined,
-						children: undefined
+            sigma: undefined, 
+            children: undefined
         })
     }
 

--- a/src/ForceAtlas2.js
+++ b/src/ForceAtlas2.js
@@ -91,7 +91,6 @@ class ForceAtlas2 extends React.Component {
 		if(this.state.timer) clearTimeout(this.state.timer)
 	}
 
-  //TODO: Add composition of child components after timeout
 	render() {
         if (!this.state.running) {
             return <div>{ embedProps(this.props.children, {sigma: this.props.sigma}) }</div>;
@@ -119,8 +118,8 @@ class ForceAtlas2 extends React.Component {
 	//strip force atlas options from component props
   _stripOptions(props: Props): Props {
         return Object.assign({}, props, {
-            sigma: undefined
-							   
+            sigma: undefined,
+						children: undefined
         })
     }
 

--- a/src/ForceAtlas2.js
+++ b/src/ForceAtlas2.js
@@ -91,7 +91,12 @@ class ForceAtlas2 extends React.Component {
 	}
 
   //TODO: Add composition of child components after timeout
-	render = () => null
+	render() {
+        if (!this.state.running) {
+            return <div>{ embedProps(this.props.children, {sigma: this.props.sigma}) }</div>;
+        }
+        return null;
+    }
 
 
 	_refreshGraph() {
@@ -111,9 +116,12 @@ class ForceAtlas2 extends React.Component {
 	}
 
 	//strip force atlas options from component props
-	_stripOptions(props: Props): Props {
-		return Object.assign({}, props, {sigma: undefined})
-	}
+  _stripOptions(props: Props): Props {
+        return Object.assign({}, props, {
+            sigma: undefined
+							   
+        })
+    }
 
 }
 

--- a/src/ForceAtlas2.js
+++ b/src/ForceAtlas2.js
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import '../sigma/layout.forceAtlas2'
+import { embedProps } from './tools'
 
 type State = {
 	running: boolean,


### PR DESCRIPTION
The children components of the ForceAtlas2 components get rendered when the ForceAtlas2 layout is done running.