### PR TITLE
Fixed custom node images

### DIFF
--- a/src/Sigma.js
+++ b/src/Sigma.js
@@ -112,7 +112,7 @@ class Sigma extends React.Component<Props, State> {
     this.state = {renderer:false}
     let settings = this.props.settings ? this.props.settings : {}
     this.sigma = new sigma({settings})
-    CustomShapes.init(this.sigma)
+    if (CustomShapes) CustomShapes.init(this.sigma)
     Sigma.bindHandlers(this.props, this.sigma)
     if(this.props.graph) {
       try {

--- a/src/Sigma.js
+++ b/src/Sigma.js
@@ -112,6 +112,7 @@ class Sigma extends React.Component<Props, State> {
     this.state = {renderer:false}
     let settings = this.props.settings ? this.props.settings : {}
     this.sigma = new sigma({settings})
+    CustomShapes.init(this.sigma)
     Sigma.bindHandlers(this.props, this.sigma)
     if(this.props.graph) {
       try {


### PR DESCRIPTION
Custom node images were not working because the CustomNodes plugin wasn't being initialized.

See https://github.com/dunnock/react-sigma/issues/73#issuecomment-528971088