### PR TITLE
Adds option for seeded random nodes

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -360,6 +360,10 @@ preloaded, or within loader component, like LoadJSON.
 RandomizeNodePositions component, sets random positions to all nodes.
 Can be used within Sigma component with predefined graph or within graph loader component.
 
+**Parameters**
+
+-   `seed` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Random position seed (optional, defaults to random number between 1 and 1e6)
+
 # RelativeSize
 
 [src/RelativeSize.js:25-34](https://github.com/dunnock/react-sigma/blob/22ffeb743b9893354171f025edc217e4241ca70c/src/RelativeSize.js#L25-L34 "Source code on GitHub")

--- a/src/RandomizeNodePositions.js
+++ b/src/RandomizeNodePositions.js
@@ -3,11 +3,13 @@
 import React from 'react'
 import { embedProps } from './tools'
 
+const randomSeed = Math.random() * 10001
+
 type Props = {
   children?: mixed,
-  sigma?: sigma
-};
-
+  sigma?: sigma,
+  seed?: number
+}
 
 /**
 
@@ -18,25 +20,41 @@ Can be used within Sigma component with predefined graph or within graph loader 
 
 
 class RandomizeNodePositions extends React.PureComponent<Props> {
-  constructor(props: Props) {
-    super(props)
-    if(this.props.sigma) {
-      this.props.sigma.graph.nodes().forEach(n => {
-        n.x = Math.random()
-        n.y = Math.random()
+  constructor( props: Props ) {
+    super( props )
+
+    let initSeed
+    if ( this.props.seed != null ) {
+      initSeed = this.props.seed
+    } else {
+      initSeed = Math.floor( Math.random() * 100001 )
+    }
+    this.state = {
+      seed: initSeed
+    }
+    if ( this.props.sigma ) {
+      this.props.sigma.graph.nodes().forEach( ( n, idn ) => {
+        console.log( this.random() )
+        n.x = this.random()
+        n.y = this.random()
       } )
     }
-    if(this.props.sigma) this.props.sigma.refresh()
+    if ( this.props.sigma ) this.props.sigma.refresh()
+  }
+
+  random() {
+    let s = Math.sin( this.state.seed++ ) * 10000
+    return s - Math.floor( s )
   }
 
   componentDidMount() {
-    if(this.props.sigma) this.props.sigma.refresh()
+    if ( this.props.sigma ) this.props.sigma.refresh()
   }
 
   render() {
-    return <div>{ embedProps(this.props.children, {sigma: this.props.sigma}) }</div>
+    return <div>{embedProps( this.props.children, { sigma: this.props.sigma } )}</div>
   }
 
 }
 
-export default RandomizeNodePositions;
+export default RandomizeNodePositions

--- a/stories-src/storiesOfLoading.js
+++ b/stories-src/storiesOfLoading.js
@@ -10,6 +10,15 @@ storiesOf('Loading', module)
       </LoadJSON>
   	</Sigma>
   ))
+  .add( 'LoadJSON without coords seeded', () => {
+    return (
+      <Sigma>
+        <LoadJSON path={String( process.env.PUBLIC_URL ) + "/geolocalized.json"}>
+          <RandomizeNodePositions seed={42} />
+        </LoadJSON>
+      </Sigma>
+    )
+  } )
   .add('LoadJSON with coords', () => (
     <Sigma>
       <LoadJSON path={String(process.env.PUBLIC_URL) + "/arctic.json"}/>


### PR DESCRIPTION
I was looking for a way to have graphs appear a somewhat more consistently without requiring precomputed positions.

I decided to try and extend the `RandomizeNodePositions` component to allow for including a seed for randomization.

This does come at the cost of implementing a `random` function within the component, therefore not leveraging the `Math.random` functionality directly. I chose a very simple random number generator based on the discussion in this StackOverflow:

https://stackoverflow.com/questions/521295/seeding-the-random-number-generator-in-javascript/47593316

I also added a storybook example, which should always render the same graph.

Sorry if there are any issues, I am not familiar with Flow typing.

